### PR TITLE
Updated tags for NIJI EN Wave 4/Fixed Kurohana Inori Twitter

### DIFF
--- a/service/migrate/json/CyberLive.json
+++ b/service/migrate/json/CyberLive.json
@@ -199,7 +199,7 @@
 			"Twitter": {
 				"Twitter_Fanart": "#illustnori",
 				"Twitter_Lewd": "#kurohorni",
-				"Twitter_Username": "KuroharaInori"
+				"Twitter_Username": "KurohanaInori"
 			},
 			"Youtube": {
 				"Yt_ID": "UCTM9UNM9o4lYmQpRJp0QL1A"

--- a/service/migrate/json/Nijisanji.json
+++ b/service/migrate/json/Nijisanji.json
@@ -2119,7 +2119,7 @@
 			"JP_Name": "ルカ・カネシロ",
 			"Twitter": {
 				"Twitter_Fanart": "#drawluca",
-				"Twitter_Lewd": "",
+				"Twitter_Lewd": "#lucadeeznuts",
 				"Twitter_Username": "luca_kaneshiro"
 			},
 			"Youtube": {
@@ -2137,7 +2137,7 @@
 			"JP_Name": "闇ノシュウ",
 			"Twitter": {
 				"Twitter_Fanart": "#YaminoArt",
-				"Twitter_Lewd": "",
+				"Twitter_Lewd": "#Shussy",
 				"Twitter_Username": "shu_yamino"
 			},
 			"Youtube": {
@@ -2190,8 +2190,8 @@
 			"EN_Name": "Vox Akuma",
 			"JP_Name": "ヴォックス・アクマ",
 			"Twitter": {
-				"Twitter_Fanart": "#AkumArt",
-				"Twitter_Lewd": "#VoXxX",
+				"Twitter_Fanart": "#Akurylic",
+				"Twitter_Lewd": "#Akumasutra",
 				"Twitter_Username": "Vox_Akuma"
 			},
 			"Youtube": {


### PR DESCRIPTION
Hey Just_Humanz, here is quick hotfix which fixes the error displaying on log and updating the tags for NIJI EN Wave 4

# NIJISANJI
* Updated tags for Luca Kaneshiro, Shu Yamino, Vox Akuma

# CyberLive
* Fixed wrong twitter id for Kurohana Inori