### PR TITLE
Remove cache before updating status

### DIFF
--- a/service/livestream/bilibili/live/live.go
+++ b/service/livestream/bilibili/live/live.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -189,7 +190,16 @@ func (i *checkBlLiveeJob) Run() {
 										}
 									}())
 
-								err := Bili.UpdateLiveBili()
+									//Remove cache before update the status
+								err := Bili.RemoveCache(fmt.Sprintf("%d-%s-%s-%d", Member.ID, Member.Name, config.PastStatus, Member.BiliBiliID))
+								if err != nil {
+									log.WithFields(log.Fields{
+										"Agency": Agency.GroupName,
+										"Vtuber": Member.Name,
+									}).Error(err)
+								}
+
+								err = Bili.UpdateLiveBili()
 								if err != nil {
 									log.WithFields(log.Fields{
 										"Agency": Agency.GroupName,
@@ -222,6 +232,15 @@ func (i *checkBlLiveeJob) Run() {
 								engine.RemoveEmbed(strconv.Itoa(Bili.Member.BiliBiliRoomID), Bot)
 								Bili.UpdateEnd(time.Now()).
 									UpdateStatus(config.PastStatus)
+
+									//Remove cache before update the status
+								err := Bili.RemoveCache(fmt.Sprintf("%d-%s-%s-%d", Member.ID, Member.Name, config.LiveStatus, Member.BiliBiliID))
+								if err != nil {
+									log.WithFields(log.Fields{
+										"Agency": Agency.GroupName,
+										"Vtuber": Member.Name,
+									}).Error(err)
+								}
 
 								err = Bili.UpdateLiveBili()
 								if err != nil {


### PR DESCRIPTION
the RCA of this was,the cache not being deleted when bot update the live status then bot read the cache first and make bot not realize if the vtuber was already in live status

![Screenshot from 2022-05-27 20-10-34](https://user-images.githubusercontent.com/43176061/170706797-db60ff7c-7f75-4aed-ab24-d06ee05dd2c4.png)
