### PR TITLE
[FIX] Youtube Video counts always `2017` and disable BiliBili Video Count

### DIFF
--- a/service/new-web-vue/src/components/VtuberDetails/BiliBiliCount.vue
+++ b/service/new-web-vue/src/components/VtuberDetails/BiliBiliCount.vue
@@ -20,12 +20,12 @@
         </span>
         <span class="card-title">Viewers</span>
       </div>
-      <div class="platform-card">
+      <!-- <div class="platform-card">
         <span class="card-count">
           <CountTo :endVal="bilibili.TotalVideos" />
         </span>
         <span class="card-title">Videos/Archives</span>
-      </div>
+      </div> -->
     </div>
   </div>
   <hr class="m-2" />

--- a/service/new-web-vue/src/components/VtuberDetails/YoutubeCount.vue
+++ b/service/new-web-vue/src/components/VtuberDetails/YoutubeCount.vue
@@ -33,7 +33,7 @@
       </div>
       <div class="platform-card">
         <span class="card-count">
-          <CountTo :endVal="youtube.VideoCount" />
+          <CountTo :endVal="youtube.TotalVideos" />
         </span>
         <span class="card-title">Videos/Archives</span>
       </div>


### PR DESCRIPTION
- Fix Youtube Video Count to 2017 (default vue3-count-to package) with change code `youtube.VideoCount` to `youtube.TotalVideos` (like key in API) 
- Disable Bilibili video because showing Video count always 0 in API's