### PR TITLE
Rework `List View` and add `Advanced Filter`

### DIFF
--- a/service/new-web-vue/package-lock.json
+++ b/service/new-web-vue/package-lock.json
@@ -23,7 +23,8 @@
         "vue": "^3.2.29",
         "vue-i18n": "^9.1.10",
         "vue-router": "^4.0.12",
-        "vue3-count-to": "^1.1.2"
+        "vue3-count-to": "^1.1.2",
+        "wanakana": "^5.0.2"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^2.1.0",
@@ -2646,6 +2647,14 @@
         "vue": ">= 3 < 4"
       }
     },
+    "node_modules/wanakana": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/wanakana/-/wanakana-5.0.2.tgz",
+      "integrity": "sha512-eYTezpLYXCr+gmVmgBBYQP7A7WJphvhyx1PkrHaMrnExTiMPrgTgFLSJgo75DnZf1Wy0lA2nukNVJg7Ptvx9zA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -4383,6 +4392,11 @@
         "core-js": "^3.8.1",
         "vue-count-to": "^1.0.13"
       }
+    },
+    "wanakana": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/wanakana/-/wanakana-5.0.2.tgz",
+      "integrity": "sha512-eYTezpLYXCr+gmVmgBBYQP7A7WJphvhyx1PkrHaMrnExTiMPrgTgFLSJgo75DnZf1Wy0lA2nukNVJg7Ptvx9zA=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/service/new-web-vue/package-lock.json
+++ b/service/new-web-vue/package-lock.json
@@ -21,6 +21,7 @@
         "url-parse": "^1.5.10",
         "validator": "^13.7.0",
         "vue": "^3.2.29",
+        "vue-i18n": "^9.1.10",
         "vue-router": "^4.0.12",
         "vue3-count-to": "^1.1.2"
       },
@@ -111,6 +112,88 @@
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "vue": ">= 3.0.0 < 4"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.1.10.tgz",
+      "integrity": "sha512-So9CNUavB/IsZ+zBmk2Cv6McQp6vc2wbGi1S0XQmJ8Vz+UFcNn9MFXAe9gY67PreIHrbLsLxDD0cwo1qsxM1Nw==",
+      "dependencies": {
+        "@intlify/devtools-if": "9.1.10",
+        "@intlify/message-compiler": "9.1.10",
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/runtime": "9.1.10",
+        "@intlify/shared": "9.1.10",
+        "@intlify/vue-devtools": "9.1.10"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/devtools-if": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-if/-/devtools-if-9.1.10.tgz",
+      "integrity": "sha512-SHaKoYu6sog3+Q8js1y3oXLywuogbH1sKuc7NSYkN3GElvXSBaMoCzW+we0ZSFqj/6c7vTNLg9nQ6rxhKqYwnQ==",
+      "dependencies": {
+        "@intlify/shared": "9.1.10"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.1.10.tgz",
+      "integrity": "sha512-+JiJpXff/XTb0EadYwdxOyRTB0hXNd4n1HaJ/a4yuV960uRmPXaklJsedW0LNdcptd/hYUZtCkI7Lc9J5C1gxg==",
+      "dependencies": {
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/shared": "9.1.10",
+        "source-map": "0.6.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/message-resolver": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/message-resolver/-/message-resolver-9.1.10.tgz",
+      "integrity": "sha512-5YixMG/M05m0cn9+gOzd4EZQTFRUu8RGhzxJbR1DWN21x/Z3bJ8QpDYj6hC4FwBj5uKsRfKpJQ3Xqg98KWoA+w==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/runtime": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/runtime/-/runtime-9.1.10.tgz",
+      "integrity": "sha512-7QsuByNzpe3Gfmhwq6hzgXcMPpxz8Zxb/XFI6s9lQdPLPe5Lgw4U1ovRPZTOs6Y2hwitR3j/HD8BJNGWpJnOFA==",
+      "dependencies": {
+        "@intlify/message-compiler": "9.1.10",
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/shared": "9.1.10"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.1.10.tgz",
+      "integrity": "sha512-Om54xJeo1Vw+K1+wHYyXngE8cAbrxZHpWjYzMR9wCkqbhGtRV5VLhVc214Ze2YatPrWlS2WSMOWXR8JktX/IgA==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/vue-devtools": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-devtools/-/vue-devtools-9.1.10.tgz",
+      "integrity": "sha512-5l3qYARVbkWAkagLu1XbDUWRJSL8br1Dj60wgMaKB0+HswVsrR6LloYZTg7ozyvM621V6+zsmwzbQxbVQyrytQ==",
+      "dependencies": {
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/runtime": "9.1.10",
+        "@intlify/shared": "9.1.10"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2520,6 +2603,23 @@
       "resolved": "https://registry.npmjs.org/vue-count-to/-/vue-count-to-1.0.13.tgz",
       "integrity": "sha512-6R4OVBVNtQTlcbXu6SJ8ENR35M2/CdWt3Jmv57jOUM+1ojiFmjVGvZPH8DfHpMDSA+ITs+EW5V6qthADxeyYOQ=="
     },
+    "node_modules/vue-i18n": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.1.10.tgz",
+      "integrity": "sha512-jpr7gV5KPk4n+sSPdpZT8Qx3XzTcNDWffRlHV/cT2NUyEf+sEgTTmLvnBAibjOFJ0zsUyZlVTAWH5DDnYep+1g==",
+      "dependencies": {
+        "@intlify/core-base": "9.1.10",
+        "@intlify/shared": "9.1.10",
+        "@intlify/vue-devtools": "9.1.10",
+        "@vue/devtools-api": "^6.0.0-beta.7"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.16.tgz",
@@ -2676,6 +2776,67 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.1.tgz",
       "integrity": "sha512-CdXZJoCS+aEPec26ZP7hWWU3SaJlQPZSCGdgpQ2qGl2HUmtUUNrI3zC4XWdn1JUmh3t5OuDeRG1qB4eGRNSD4A==",
       "requires": {}
+    },
+    "@intlify/core-base": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.1.10.tgz",
+      "integrity": "sha512-So9CNUavB/IsZ+zBmk2Cv6McQp6vc2wbGi1S0XQmJ8Vz+UFcNn9MFXAe9gY67PreIHrbLsLxDD0cwo1qsxM1Nw==",
+      "requires": {
+        "@intlify/devtools-if": "9.1.10",
+        "@intlify/message-compiler": "9.1.10",
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/runtime": "9.1.10",
+        "@intlify/shared": "9.1.10",
+        "@intlify/vue-devtools": "9.1.10"
+      }
+    },
+    "@intlify/devtools-if": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/devtools-if/-/devtools-if-9.1.10.tgz",
+      "integrity": "sha512-SHaKoYu6sog3+Q8js1y3oXLywuogbH1sKuc7NSYkN3GElvXSBaMoCzW+we0ZSFqj/6c7vTNLg9nQ6rxhKqYwnQ==",
+      "requires": {
+        "@intlify/shared": "9.1.10"
+      }
+    },
+    "@intlify/message-compiler": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.1.10.tgz",
+      "integrity": "sha512-+JiJpXff/XTb0EadYwdxOyRTB0hXNd4n1HaJ/a4yuV960uRmPXaklJsedW0LNdcptd/hYUZtCkI7Lc9J5C1gxg==",
+      "requires": {
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/shared": "9.1.10",
+        "source-map": "0.6.1"
+      }
+    },
+    "@intlify/message-resolver": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/message-resolver/-/message-resolver-9.1.10.tgz",
+      "integrity": "sha512-5YixMG/M05m0cn9+gOzd4EZQTFRUu8RGhzxJbR1DWN21x/Z3bJ8QpDYj6hC4FwBj5uKsRfKpJQ3Xqg98KWoA+w=="
+    },
+    "@intlify/runtime": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/runtime/-/runtime-9.1.10.tgz",
+      "integrity": "sha512-7QsuByNzpe3Gfmhwq6hzgXcMPpxz8Zxb/XFI6s9lQdPLPe5Lgw4U1ovRPZTOs6Y2hwitR3j/HD8BJNGWpJnOFA==",
+      "requires": {
+        "@intlify/message-compiler": "9.1.10",
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/shared": "9.1.10"
+      }
+    },
+    "@intlify/shared": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.1.10.tgz",
+      "integrity": "sha512-Om54xJeo1Vw+K1+wHYyXngE8cAbrxZHpWjYzMR9wCkqbhGtRV5VLhVc214Ze2YatPrWlS2WSMOWXR8JktX/IgA=="
+    },
+    "@intlify/vue-devtools": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@intlify/vue-devtools/-/vue-devtools-9.1.10.tgz",
+      "integrity": "sha512-5l3qYARVbkWAkagLu1XbDUWRJSL8br1Dj60wgMaKB0+HswVsrR6LloYZTg7ozyvM621V6+zsmwzbQxbVQyrytQ==",
+      "requires": {
+        "@intlify/message-resolver": "9.1.10",
+        "@intlify/runtime": "9.1.10",
+        "@intlify/shared": "9.1.10"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4194,6 +4355,17 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/vue-count-to/-/vue-count-to-1.0.13.tgz",
       "integrity": "sha512-6R4OVBVNtQTlcbXu6SJ8ENR35M2/CdWt3Jmv57jOUM+1ojiFmjVGvZPH8DfHpMDSA+ITs+EW5V6qthADxeyYOQ=="
+    },
+    "vue-i18n": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.1.10.tgz",
+      "integrity": "sha512-jpr7gV5KPk4n+sSPdpZT8Qx3XzTcNDWffRlHV/cT2NUyEf+sEgTTmLvnBAibjOFJ0zsUyZlVTAWH5DDnYep+1g==",
+      "requires": {
+        "@intlify/core-base": "9.1.10",
+        "@intlify/shared": "9.1.10",
+        "@intlify/vue-devtools": "9.1.10",
+        "@vue/devtools-api": "^6.0.0-beta.7"
+      }
     },
     "vue-router": {
       "version": "4.0.16",

--- a/service/new-web-vue/package.json
+++ b/service/new-web-vue/package.json
@@ -24,7 +24,8 @@
     "vue": "^3.2.29",
     "vue-i18n": "^9.1.10",
     "vue-router": "^4.0.12",
-    "vue3-count-to": "^1.1.2"
+    "vue3-count-to": "^1.1.2",
+    "wanakana": "^5.0.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.1.0",

--- a/service/new-web-vue/package.json
+++ b/service/new-web-vue/package.json
@@ -22,6 +22,7 @@
     "url-parse": "^1.5.10",
     "validator": "^13.7.0",
     "vue": "^3.2.29",
+    "vue-i18n": "^9.1.10",
     "vue-router": "^4.0.12",
     "vue3-count-to": "^1.1.2"
   },

--- a/service/new-web-vue/src/App.vue
+++ b/service/new-web-vue/src/App.vue
@@ -358,7 +358,7 @@ export default {
 <style lang="scss" scoped>
 .nav {
   font-family: "Nunito", sans-serif;
-  @apply sticky top-0 left-0 z-[11] flex h-16 w-screen select-none justify-center bg-cyan-500 shadow-md shadow-cyan-500/50 dark:bg-slate-700 dark:shadow-slate-700/50;
+  @apply sticky top-0 left-0 z-[20] flex h-16 w-screen select-none justify-center bg-cyan-500 shadow-md shadow-cyan-500/50 dark:bg-slate-700 dark:shadow-slate-700/50;
   .navbar {
     @apply mx-4 flex h-full w-full items-center justify-between md:w-[90%] md:justify-around lg:w-[85%];
 

--- a/service/new-web-vue/src/App.vue
+++ b/service/new-web-vue/src/App.vue
@@ -248,6 +248,8 @@ library.add(
   faRightToBracket
 )
 
+import { useMemberStore } from "@/stores/members.js"
+
 export default {
   data() {
     return {
@@ -270,6 +272,12 @@ export default {
       async () => {
         this.isActiveVtuber = this.$route.path.includes("/vtuber")
         this.isActiveDocs = this.$route.path.includes("/docs")
+
+        if (
+          !this.$route.path.includes("/vtubers") &&
+          useMemberStore().menuFilter.open_advanced
+        )
+          useMemberStore().toggleadvanced()
       },
 
       { immediate: true }

--- a/service/new-web-vue/src/agency.json
+++ b/service/new-web-vue/src/agency.json
@@ -1,0 +1,7 @@
+{
+  "5:jp": "$Hololive",
+  "6:cn": "VirtuaReal",
+  "6:jp": "$Nijisanji",
+  "6:kr": "Nijisanji",
+  "6:id": "Nijisanji"
+}

--- a/service/new-web-vue/src/assets/langs/en.json
+++ b/service/new-web-vue/src/assets/langs/en.json
@@ -1,0 +1,5 @@
+{
+  "home_head": "Friend for get notification from vtuber",
+  "home_add": "Add to Discord",
+  "home_live_title": "Get any live notification over +400 vtubers."
+}

--- a/service/new-web-vue/src/components/ExtendFilter.vue
+++ b/service/new-web-vue/src/components/ExtendFilter.vue
@@ -1,0 +1,161 @@
+<template>
+  <div class="extend-filter">
+    <h3 class="extend-filter__title">Regions</h3>
+    <div class="extend-filter_items">
+      <div class="extend-filter__item" v-for="region in regions">
+        <input
+          type="checkbox"
+          :id="`${region.code.toLowerCase()}_filter`"
+          name="filter-check"
+          :value="region.code.toLowerCase()"
+          class="extend-filter__item-input"
+        />
+        <label
+          :for="`${region.code.toLowerCase()}_filter`"
+          class="extend-filter__item-label"
+        >
+          <img
+            draggable="false"
+            class="extend-filter__item-flag"
+            :src="`/assets/flags/${region.code.toLowerCase()}.svg`"
+            :alt="region.code"
+            onerror="this.src='/assets/flags/none.svg'"
+          />
+          <span class="extend-filter__item-text">{{ region.name }}</span>
+        </label>
+      </div>
+    </div>
+    <h3 class="extend-filter__title">Platform</h3>
+    <div class="extend-filter_items">
+      <div class="extend-filter__item" v-if="platforms.includes('youtube')">
+        <input
+          type="checkbox"
+          id="yt_plat"
+          name="platform-check"
+          value="youtube"
+          class="extend-filter__item-input"
+        />
+        <label for="yt_plat" class="extend-filter__item-label">
+          <font-awesome-icon
+            :icon="['fab', 'youtube']"
+            class="extend-filter__item-icon"
+          />
+          <span class="extend-filter__item-text">Youtube</span>
+        </label>
+      </div>
+
+      <div class="extend-filter__item" v-if="platforms.includes('twitch')">
+        <input
+          type="checkbox"
+          id="tw_plat"
+          name="platform-check"
+          value="twitch"
+          class="extend-filter__item-input"
+        />
+        <label for="tw_plat" class="extend-filter__item-label">
+          <font-awesome-icon
+            :icon="['fab', 'twitch']"
+            class="extend-filter__item-icon"
+          />
+          <span class="extend-filter__item-text">Twitch</span>
+        </label>
+      </div>
+
+      <div class="extend-filter__item" v-if="platforms.includes('bilibili')">
+        <input
+          type="checkbox"
+          id="bili_plat"
+          name="platform-check"
+          value="bilibili"
+          class="extend-filter__item-input"
+        />
+        <label for="bili_plat" class="extend-filter__item-label">
+          <font-awesome-icon
+            :icon="['fab', 'bilibili']"
+            class="extend-filter__item-icon"
+          />
+          <span class="extend-filter__item-text">Bilibili</span>
+        </label>
+      </div>
+
+      <div class="extend-filter__item" v-if="platforms.length > 1">
+        <input
+          type="checkbox"
+          id="select_reverse"
+          name="select_reverse"
+          class="extend-filter__item-input"
+        />
+        <label for="select_reverse" class="extend-filter__item-label">
+          <font-awesome-icon
+            icon="circle-check"
+            class="extend-filter__item-icon"
+          />
+          <span class="extend-filter__item-text">Select Except</span>
+        </label>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { library } from "@fortawesome/fontawesome-svg-core"
+import { faCircleCheck } from "@fortawesome/free-solid-svg-icons"
+library.add(faCircleCheck)
+
+import { useMemberStore } from "@/stores/members.js"
+import regions from "@/regions.json"
+
+export default {
+  mounted() {
+    console.log(regions)
+  },
+  computed: {
+    regions() {
+      const filtersMenu = useMemberStore().menuFilter
+      return filtersMenu.region.map((region) => {
+        for (const r of regions) {
+          if (r.code.toLowerCase() === region.toLowerCase()) return r
+        }
+      })
+    },
+    platforms() {
+      const filtersMenu = useMemberStore().menuFilter
+      return filtersMenu.platform
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.extend-filter {
+  @apply fixed top-16 z-[15] mb-3 w-screen select-none bg-slate-100 py-2 px-5 shadow-md dark:bg-slate-400;
+
+  &__title {
+    @apply text-lg font-semibold text-white;
+  }
+
+  &__items {
+    @apply flex items-center;
+  }
+
+  &__item {
+    @apply m-0.5 inline-block;
+
+    &-input {
+      @apply hidden;
+
+      &:checked ~ .extend-filter__item-label {
+        @apply bg-white text-slate-700;
+      }
+    }
+
+    &-label {
+      @apply flex cursor-pointer items-center space-x-1 rounded-full border-2 border-white px-3 py-1 text-sm text-white transition-all duration-200 ease-in-out;
+    }
+
+    &-flag {
+      @apply inline-block w-5 min-w-[1.25rem] object-contain drop-shadow-md;
+    }
+  }
+}
+</style>

--- a/service/new-web-vue/src/components/ExtendFilter.vue
+++ b/service/new-web-vue/src/components/ExtendFilter.vue
@@ -1,150 +1,210 @@
 <template>
-  <div class="extend-filter">
-    <h3 class="extend-filter__title">Regions</h3>
-    <div class="extend-filter_items">
-      <div class="extend-filter__item" v-for="region in regions">
-        <input
-          type="checkbox"
-          :id="`${region.code.toLowerCase()}_filter`"
-          name="filter-check"
-          :value="region.code.toLowerCase()"
-          class="extend-filter__item-input"
-        />
-        <label
-          :for="`${region.code.toLowerCase()}_filter`"
-          class="extend-filter__item-label"
-        >
-          <img
-            draggable="false"
-            class="extend-filter__item-flag"
-            :src="`/assets/flags/${region.code.toLowerCase()}.svg`"
-            :alt="region.code"
-            onerror="this.src='/assets/flags/none.svg'"
+  <div class="bg-filter">
+    <div class="extend-filter">
+      <h3 class="extend-filter__title" v-if="regions.length > 1">Regions</h3>
+      <div class="extend-filter_items" v-if="regions.length > 1">
+        <div class="extend-filter__item" v-for="region in regions">
+          <input
+            type="checkbox"
+            :id="`${region.code.toLowerCase()}_filter`"
+            name="filter-check"
+            :value="region.code.toLowerCase()"
+            @change="changeLang"
+            class="extend-filter__item-input"
+            :checked="old_regions.includes(region.code.toLowerCase())"
           />
-          <span class="extend-filter__item-text">{{ region.name }}</span>
-        </label>
+          <label
+            :for="`${region.code.toLowerCase()}_filter`"
+            class="extend-filter__item-label"
+          >
+            <img
+              draggable="false"
+              class="extend-filter__item-flag"
+              :src="`/assets/flags/${region.code.toLowerCase()}.svg`"
+              :alt="region.code"
+              onerror="this.src='/assets/flags/none.svg'"
+            />
+            <span class="extend-filter__item-text">{{ region.name }}</span>
+          </label>
+        </div>
       </div>
-    </div>
-    <h3 class="extend-filter__title">Platform</h3>
-    <div class="extend-filter_items">
-      <div class="extend-filter__item" v-if="platforms.includes('youtube')">
-        <input
-          type="checkbox"
-          id="yt_plat"
-          name="live-check"
-          value="youtube"
-          class="extend-filter__item-input"
-        />
-        <label for="yt_plat" class="extend-filter__item-label">
-          <font-awesome-icon
-            :icon="['fab', 'youtube']"
-            class="extend-filter__item-icon"
+      <h3 class="extend-filter__title" v-if="platforms.length > 1">Platform</h3>
+      <div class="extend-filter_items" v-if="platforms.length > 1">
+        <div class="extend-filter__item" v-if="platforms.includes('youtube')">
+          <input
+            type="checkbox"
+            id="yt_plat"
+            name="platform-check"
+            value="yt"
+            class="extend-filter__item-input"
+            @change="changePlatform"
+            :checked="old_platforms.includes('yt')"
           />
-          <span class="extend-filter__item-text">Youtube</span>
-        </label>
+          <label for="yt_plat" class="extend-filter__item-label">
+            <font-awesome-icon
+              :icon="['fab', 'youtube']"
+              class="extend-filter__item-icon"
+            />
+            <span class="extend-filter__item-text">Youtube</span>
+          </label>
+        </div>
+
+        <div class="extend-filter__item" v-if="platforms.includes('twitch')">
+          <input
+            type="checkbox"
+            id="tw_plat"
+            name="platform-check"
+            value="tw"
+            class="extend-filter__item-input"
+            @change="changePlatform"
+            :checked="old_platforms.includes('tw')"
+          />
+          <label for="tw_plat" class="extend-filter__item-label">
+            <font-awesome-icon
+              :icon="['fab', 'twitch']"
+              class="extend-filter__item-icon"
+            />
+            <span class="extend-filter__item-text">Twitch</span>
+          </label>
+        </div>
+
+        <div class="extend-filter__item" v-if="platforms.includes('bilibili')">
+          <input
+            type="checkbox"
+            id="bili_plat"
+            name="platform-check"
+            value="bl"
+            class="extend-filter__item-input"
+            @change="changePlatform"
+            :checked="old_platforms.includes('bl')"
+          />
+          <label for="bili_plat" class="extend-filter__item-label">
+            <font-awesome-icon
+              :icon="['fab', 'bilibili']"
+              class="extend-filter__item-icon"
+            />
+            <span class="extend-filter__item-text">Bilibili</span>
+          </label>
+        </div>
+
+        <div class="extend-filter__item" v-if="platforms.length > 1">
+          <input
+            type="checkbox"
+            id="select_reverse"
+            name="select_reverse"
+            class="extend-filter__item-input"
+            @change="checkSelectOnly"
+            :checked="select_only"
+          />
+          <label for="select_reverse" class="extend-filter__item-label">
+            <font-awesome-icon
+              icon="circle-check"
+              class="extend-filter__item-icon"
+            />
+            <span class="extend-filter__item-text">Select Only</span>
+          </label>
+        </div>
+      </div>
+      <h3 class="extend-filter__title" v-if="live.length > 1">Live Platform</h3>
+      <div class="extend-filter_items" v-if="live.length > 1">
+        <div class="extend-filter__item" v-if="live.includes('youtube')">
+          <input
+            type="checkbox"
+            id="yt_live"
+            name="live-check"
+            value="yt"
+            class="extend-filter__item-input"
+            @change="changeLive"
+            :checked="old_live.includes('yt')"
+          />
+          <label for="yt_live" class="extend-filter__item-label">
+            <font-awesome-icon
+              :icon="['fab', 'youtube']"
+              class="extend-filter__item-icon"
+            />
+            <span class="extend-filter__item-text">Youtube</span>
+          </label>
+        </div>
+
+        <div class="extend-filter__item" v-if="live.includes('twitch')">
+          <input
+            type="checkbox"
+            id="tw_live"
+            name="live-check"
+            value="tw"
+            class="extend-filter__item-input"
+            @change="changeLive"
+            :checked="old_live.includes('tw')"
+          />
+          <label for="tw_live" class="extend-filter__item-label">
+            <font-awesome-icon
+              :icon="['fab', 'twitch']"
+              class="extend-filter__item-icon"
+            />
+            <span class="extend-filter__item-text">Twitch</span>
+          </label>
+        </div>
+
+        <div class="extend-filter__item" v-if="live.includes('bilibili')">
+          <input
+            type="checkbox"
+            id="bili_live"
+            name="live-check"
+            value="bl"
+            class="extend-filter__item-input"
+            @change="changeLive"
+            :checked="old_live.includes('bl')"
+          />
+          <label for="bili_live" class="extend-filter__item-label">
+            <font-awesome-icon
+              :icon="['fab', 'bilibili']"
+              class="extend-filter__item-icon"
+            />
+            <span class="extend-filter__item-text">Bilibili</span>
+          </label>
+        </div>
       </div>
 
-      <div class="extend-filter__item" v-if="platforms.includes('twitch')">
-        <input
-          type="checkbox"
-          id="tw_plat"
-          name="platform-check"
-          value="twitch"
-          class="extend-filter__item-input"
-        />
-        <label for="tw_plat" class="extend-filter__item-label">
-          <font-awesome-icon
-            :icon="['fab', 'twitch']"
-            class="extend-filter__item-icon"
+      <h3 class="extend-filter__title" v-if="live.length > 0 || inactive_check">
+        Groups
+      </h3>
+      <div class="extend-filter_items" v-if="live.length > 0 || inactive_check">
+        <div class="extend-filter__item" v-if="live.length > 0">
+          <input
+            type="checkbox"
+            id="only_live"
+            name="only_live"
+            value="true"
+            class="extend-filter__item-input"
+            :checked="live_only"
+            @change="groupChange"
           />
-          <span class="extend-filter__item-text">Twitch</span>
-        </label>
+          <label for="only_live" class="extend-filter__item-label">
+            <font-awesome-icon icon="users" class="extend-filter__item-icon" />
+            <span class="extend-filter__item-text">Live Only</span>
+          </label>
+        </div>
+
+        <div class="extend-filter__item" v-if="inactive_check">
+          <input
+            type="checkbox"
+            id="inactive"
+            name="inactive"
+            value="true"
+            class="extend-filter__item-input"
+            :checked="inactive"
+            @change="groupChange"
+          />
+          <label for="inactive" class="extend-filter__item-label">
+            <font-awesome-icon icon="skull" class="extend-filter__item-icon" />
+            <span class="extend-filter__item-text">Inactive Only</span>
+          </label>
+        </div>
       </div>
 
-      <div class="extend-filter__item" v-if="platforms.includes('bilibili')">
-        <input
-          type="checkbox"
-          id="bili_plat"
-          name="platform-check"
-          value="bilibili"
-          class="extend-filter__item-input"
-        />
-        <label for="bili_plat" class="extend-filter__item-label">
-          <font-awesome-icon
-            :icon="['fab', 'bilibili']"
-            class="extend-filter__item-icon"
-          />
-          <span class="extend-filter__item-text">Bilibili</span>
-        </label>
-      </div>
-
-      <div class="extend-filter__item" v-if="platforms.length > 1">
-        <input
-          type="checkbox"
-          id="select_reverse"
-          name="select_reverse"
-          class="extend-filter__item-input"
-        />
-        <label for="select_reverse" class="extend-filter__item-label">
-          <font-awesome-icon
-            icon="circle-check"
-            class="extend-filter__item-icon"
-          />
-          <span class="extend-filter__item-text">Select Only</span>
-        </label>
-      </div>
-    </div>
-    <h3 class="extend-filter__title">Live Platform</h3>
-    <div class="extend-filter_items">
-      <div class="extend-filter__item" v-if="platforms.includes('youtube')">
-        <input
-          type="checkbox"
-          id="yt_live"
-          name="platform-check"
-          value="youtube"
-          class="extend-filter__item-input"
-        />
-        <label for="yt_live" class="extend-filter__item-label">
-          <font-awesome-icon
-            :icon="['fab', 'youtube']"
-            class="extend-filter__item-icon"
-          />
-          <span class="extend-filter__item-text">Youtube</span>
-        </label>
-      </div>
-
-      <div class="extend-filter__item" v-if="platforms.includes('twitch')">
-        <input
-          type="checkbox"
-          id="tw_live"
-          name="live-check"
-          value="twitch"
-          class="extend-filter__item-input"
-        />
-        <label for="tw_live" class="extend-filter__item-label">
-          <font-awesome-icon
-            :icon="['fab', 'twitch']"
-            class="extend-filter__item-icon"
-          />
-          <span class="extend-filter__item-text">Twitch</span>
-        </label>
-      </div>
-
-      <div class="extend-filter__item" v-if="platforms.includes('bilibili')">
-        <input
-          type="checkbox"
-          id="bili_live"
-          name="live-check"
-          value="bilibili"
-          class="extend-filter__item-input"
-        />
-        <label for="bili_live" class="extend-filter__item-label">
-          <font-awesome-icon
-            :icon="['fab', 'bilibili']"
-            class="extend-filter__item-icon"
-          />
-          <span class="extend-filter__item-text">Bilibili</span>
-        </label>
+      <div class="button-area">
+        <button @click="submit" class="button-area__button">Filter</button>
+        <button @click="cancel" class="button-area__button">Cancel</button>
       </div>
     </div>
   </div>
@@ -157,10 +217,36 @@ library.add(faCircleCheck)
 
 import { useMemberStore } from "@/stores/members.js"
 import regions from "@/regions.json"
+import { onBeforeRouteLeave } from "vue-router"
 
 export default {
+  setup() {
+    onBeforeRouteLeave((to, from) => {
+      document.body.style.overflow = "auto"
+    })
+  },
+  data() {
+    return {
+      selected_regions: [],
+      selected_platforms: [],
+      selected_live: [],
+      select_only: false,
+      live_only: false,
+      inactive: false,
+    }
+  },
   mounted() {
-    console.log(regions)
+    const filters = useMemberStore().filter
+
+    // make body overflow hidden
+    document.body.style.overflow = "hidden"
+
+    this.selected_regions = [...this.old_regions] || []
+    this.selected_platforms = [...this.old_platforms] || []
+    this.selected_live = [...this.old_live] || []
+    this.select_only = filters.platform?.includes("-")
+    this.live_only = this.$route.query.liveonly === "true"
+    this.inactive = this.$route.query.inac === "true"
   },
   computed: {
     regions() {
@@ -175,13 +261,169 @@ export default {
       const filtersMenu = useMemberStore().menuFilter
       return filtersMenu.platform
     },
+    live() {
+      const filtersMenu = useMemberStore().menuFilter
+      return filtersMenu.live
+    },
+    old_regions() {
+      const filters = useMemberStore().filter
+      return filters.region || []
+    },
+    old_platforms() {
+      const filters = useMemberStore().filter
+      return filters.platform?.replace("-", "")?.split(",") || []
+    },
+    old_live() {
+      const filters = useMemberStore().filter
+      return filters.live?.split(",") || []
+    },
+    inactive_check() {
+      return useMemberStore().menuFilter.inactive
+    },
+  },
+  methods: {
+    cancel() {
+      useMemberStore().toggleadvanced()
+      document.body.style.overflow = "auto"
+    },
+    changeLang(e) {
+      const el = e.target
+
+      const value = el.value
+      const checked = el.checked || false
+
+      if (checked) this.selected_regions.push(value)
+      else this.selected_regions.splice(this.selected_regions.indexOf(value), 1)
+    },
+    changePlatform(e) {
+      const el = e.target
+
+      const value = el.value
+      const checked = el.checked || false
+
+      const platforms = document.querySelectorAll(
+        "input[name='platform-check']"
+      )
+
+      if (!this.select_only) {
+        for (const platform of platforms) {
+          if (platform.value !== value) {
+            platform.checked = false
+            this.selected_platforms.splice(
+              this.platforms.indexOf(platform.value),
+              1
+            )
+          }
+        }
+      }
+
+      if (checked) this.selected_platforms.push(value)
+      else
+        this.selected_platforms.splice(
+          this.selected_platforms.indexOf(value),
+          1
+        )
+    },
+    checkSelectOnly(e) {
+      this.select_only = e.target.checked || false
+
+      const platforms = document.querySelectorAll(
+        "input[name='platform-check']"
+      )
+
+      const check_ones =
+        [...platforms].filter((platform) => platform.checked).length < 2
+
+      if (!check_ones) {
+        platforms.forEach((platform, index) => {
+          // check index last
+          if (index !== platforms.length - 1) {
+            platform.checked = false
+            this.selected_platforms.splice(
+              this.platforms.indexOf(platform.value),
+              1
+            )
+          }
+        })
+      }
+    },
+    changeLive(e) {
+      const el = e.target
+
+      const value = el.value
+      const checked = el.checked || false
+
+      if (checked) this.selected_live.push(value)
+      else this.selected_live.splice(this.selected_live.indexOf(value), 1)
+    },
+    groupChange(e) {
+      const liveOnly_el = document.querySelector("#only_live")
+      const inactive_el = document.querySelector("#inactive")
+
+      if (e.target.id === liveOnly_el.id) {
+        this.live_only = e.target.checked || false
+        inactive_el.checked = false
+        this.inactive = false
+      } else if (e.target.id === inactive_el.id) {
+        this.inactive = e.target.checked || false
+        liveOnly_el.checked = false
+        this.live_only = false
+      }
+    },
+    async submit() {
+      const store = useMemberStore()
+
+      store.toggleadvanced()
+      document.body.style.overflow = "auto"
+
+      const query = new Object()
+
+      if (
+        this.selected_regions.length > 0 &&
+        this.selected_regions.length !== this.regions.length
+      )
+        query.reg = this.selected_regions.join(",")
+
+      if (
+        this.selected_platforms.length > 0 &&
+        this.selected_platforms.length !== this.platforms.length
+      )
+        query.plat = this.select_only
+          ? `-${this.selected_platforms[0]}`
+          : this.selected_platforms.join(",")
+
+      if (
+        this.selected_live.length > 0 &&
+        this.selected_live.length !== this.live.length
+      )
+        query.liveplat = this.selected_live.join(",")
+
+      if (this.live_only) query.liveonly = "true"
+      if (this.inactive) query.inac = "true"
+
+      // route push
+      this.$router.push({
+        path: "/vtubers",
+        params: { id: this.$route.query.id },
+        query,
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      store.filterMembers()
+      store.sortingMembers()
+    },
   },
 }
 </script>
 
 <style lang="scss" scoped>
+.bg-filter {
+  @apply fixed z-[15] h-screen w-screen bg-black/50;
+}
+
 .extend-filter {
-  @apply fixed top-16 z-[15] mb-3 w-screen select-none bg-slate-100 py-2 px-5 shadow-md dark:bg-slate-400;
+  @apply fixed top-16 mb-3 w-screen select-none overflow-y-auto overflow-x-hidden bg-slate-100 py-2 px-5 shadow-md dark:bg-slate-400;
+  max-height: calc(100vh - 64px);
 
   &__title {
     @apply text-lg font-semibold dark:text-white;
@@ -213,6 +455,14 @@ export default {
     &-flag {
       @apply inline-block w-5 min-w-[1.25rem] object-contain drop-shadow-md;
     }
+  }
+}
+
+.button-area {
+  @apply mt-3 flex justify-end;
+
+  &__button {
+    @apply mx-1 rounded-full bg-blue-400 px-3 py-1 text-sm text-white shadow-md transition-all duration-200 ease-in-out hover:translate-y-0.5 hover:shadow-sm dark:bg-white dark:text-slate-700;
   }
 }
 </style>

--- a/service/new-web-vue/src/components/ExtendFilter.vue
+++ b/service/new-web-vue/src/components/ExtendFilter.vue
@@ -422,7 +422,7 @@ export default {
 }
 
 .extend-filter {
-  @apply fixed top-16 mb-3 w-screen select-none overflow-y-auto overflow-x-hidden bg-slate-100 py-2 px-5 shadow-md dark:bg-slate-400;
+  @apply fixed top-16 mb-3 w-screen select-none overflow-y-auto overflow-x-hidden bg-slate-100 py-2 px-5 shadow-md dark:bg-slate-500;
   max-height: calc(100vh - 64px);
 
   &__title {

--- a/service/new-web-vue/src/components/ExtendFilter.vue
+++ b/service/new-web-vue/src/components/ExtendFilter.vue
@@ -31,7 +31,7 @@
         <input
           type="checkbox"
           id="yt_plat"
-          name="platform-check"
+          name="live-check"
           value="youtube"
           class="extend-filter__item-input"
         />
@@ -90,7 +90,60 @@
             icon="circle-check"
             class="extend-filter__item-icon"
           />
-          <span class="extend-filter__item-text">Select Except</span>
+          <span class="extend-filter__item-text">Select Only</span>
+        </label>
+      </div>
+    </div>
+    <h3 class="extend-filter__title">Live Platform</h3>
+    <div class="extend-filter_items">
+      <div class="extend-filter__item" v-if="platforms.includes('youtube')">
+        <input
+          type="checkbox"
+          id="yt_live"
+          name="platform-check"
+          value="youtube"
+          class="extend-filter__item-input"
+        />
+        <label for="yt_live" class="extend-filter__item-label">
+          <font-awesome-icon
+            :icon="['fab', 'youtube']"
+            class="extend-filter__item-icon"
+          />
+          <span class="extend-filter__item-text">Youtube</span>
+        </label>
+      </div>
+
+      <div class="extend-filter__item" v-if="platforms.includes('twitch')">
+        <input
+          type="checkbox"
+          id="tw_live"
+          name="live-check"
+          value="twitch"
+          class="extend-filter__item-input"
+        />
+        <label for="tw_live" class="extend-filter__item-label">
+          <font-awesome-icon
+            :icon="['fab', 'twitch']"
+            class="extend-filter__item-icon"
+          />
+          <span class="extend-filter__item-text">Twitch</span>
+        </label>
+      </div>
+
+      <div class="extend-filter__item" v-if="platforms.includes('bilibili')">
+        <input
+          type="checkbox"
+          id="bili_live"
+          name="live-check"
+          value="bilibili"
+          class="extend-filter__item-input"
+        />
+        <label for="bili_live" class="extend-filter__item-label">
+          <font-awesome-icon
+            :icon="['fab', 'bilibili']"
+            class="extend-filter__item-icon"
+          />
+          <span class="extend-filter__item-text">Bilibili</span>
         </label>
       </div>
     </div>
@@ -131,7 +184,11 @@ export default {
   @apply fixed top-16 z-[15] mb-3 w-screen select-none bg-slate-100 py-2 px-5 shadow-md dark:bg-slate-400;
 
   &__title {
-    @apply text-lg font-semibold text-white;
+    @apply text-lg font-semibold dark:text-white;
+
+    &:not(:first-child) {
+      @apply mt-2;
+    }
   }
 
   &__items {
@@ -145,12 +202,12 @@ export default {
       @apply hidden;
 
       &:checked ~ .extend-filter__item-label {
-        @apply bg-white text-slate-700;
+        @apply bg-slate-500 text-white dark:bg-white dark:text-slate-700;
       }
     }
 
     &-label {
-      @apply flex cursor-pointer items-center space-x-1 rounded-full border-2 border-white px-3 py-1 text-sm text-white transition-all duration-200 ease-in-out;
+      @apply flex cursor-pointer items-center space-x-1 rounded-full border-2 border-slate-500 px-3 py-1 text-sm transition-all duration-200 ease-in-out dark:border-white dark:text-white;
     }
 
     &-flag {

--- a/service/new-web-vue/src/components/MenuFilters/FilterMenu.vue
+++ b/service/new-web-vue/src/components/MenuFilters/FilterMenu.vue
@@ -293,7 +293,11 @@
     </li>
 
     <li class="navbar-filter-item">
-      <a href="#" class="navbar-filter-item__link" onclick="return false">
+      <a
+        href="#extend-filter"
+        class="navbar-filter-item__link"
+        onclick="return false"
+      >
         <font-awesome-icon
           class="fa-fw navbar-filter-item__svg"
           icon="plus-circle"

--- a/service/new-web-vue/src/components/MenuFilters/FilterMenu.vue
+++ b/service/new-web-vue/src/components/MenuFilters/FilterMenu.vue
@@ -258,11 +258,11 @@
           <router-link
             :to="{
               params: { id: $route.params.id },
-              query: urlParams({ noLive: 'toggle' }),
+              query: urlParams({ liveOnly: 'toggle' }),
             }"
             @click="changeFilter()"
             class="navbar-submenu-item__link"
-            :class="{ active: nolive === 'false' }"
+            :class="{ active: liveonly === 'true' }"
           >
             <font-awesome-icon
               class="fa-fw navbar-submenu-item__svg"
@@ -292,11 +292,19 @@
       </ul>
     </li>
 
-    <li class="navbar-filter-item">
+    <li
+      class="navbar-filter-item"
+      v-if="
+        getRegions.length > 1 ||
+        platforms.length > 1 ||
+        livePlatforms.length > 1
+      "
+    >
       <a
-        href="#extend-filter"
+        href="#"
         class="navbar-filter-item__link"
         onclick="return false"
+        @click="open_advanced_filter()"
       >
         <font-awesome-icon
           class="fa-fw navbar-filter-item__svg"
@@ -379,7 +387,7 @@ export default {
         this.reg = this.$route.query.reg
         this.plat = this.$route.query.plat
         this.liveplat = this.$route.query.liveplat
-        this.nolive = this.$route.query.nolive
+        this.liveonly = this.$route.query.liveonly
         this.inac = this.$route.query.inac
       },
       { immediate: true }
@@ -429,18 +437,10 @@ export default {
       region = null,
       platform = null,
       live = null,
-      noLive = null,
+      liveOnly = null,
       inactive = null,
     }) {
-      const {
-        reg,
-        plat,
-        liveplat,
-        nolive,
-        inac,
-        sort,
-        live: sortLive,
-      } = this.$route.query
+      const { reg, plat, liveplat, liveonly, inac } = this.$route.query
 
       const params = new Object()
 
@@ -452,19 +452,17 @@ export default {
       if ((!liveplat && live) || (liveplat && live !== ""))
         params.liveplat = live || liveplat
 
-      if (noLive) {
-        switch (nolive) {
-          case "false":
+      if (liveOnly) {
+        switch (liveonly) {
+          case "true":
             break
           default:
-            params.nolive = "false"
+            params.liveonly = "true"
         }
-      } else {
-        params.nolive = nolive
+      } else if (!inactive) {
+        params.liveonly = liveonly
       }
 
-      // if ((!inac && inactive) || (inac && inactive !== ""))
-      //   params.inac = inactive || inac
       if (inactive) {
         switch (inac) {
           case "true":
@@ -472,23 +470,19 @@ export default {
           default:
             params.inac = "true"
         }
-      } else {
+      } else if (!liveOnly) {
         params.inac = inac
       }
-
-      if (sort) params.sort = sort
-      if (sortLive) params.live = sortLive
 
       return params
     },
     removeAll() {
-      const { sort, live } = this.$route.query
-
       const params = new Object()
-      if (sort) params.sort = sort
-      if (live) params.live = live
 
       return params
+    },
+    open_advanced_filter() {
+      useMemberStore().toggleadvanced()
     },
   },
 }

--- a/service/new-web-vue/src/components/MenuFilters/NavbarList.vue
+++ b/service/new-web-vue/src/components/MenuFilters/NavbarList.vue
@@ -104,20 +104,18 @@ export default {
 
       if (!this.checkFilteredData) return "Search Vtubers..."
 
-      // get all EnName and JpName from filteredData
-      const EnNames = store.members.filteredData.map((member) => {
-        return member.EnName
+      let names = store.members.filteredData.filter((member) => {
+        return member.Status === "Active"
       })
 
-      const JpNames = store.members.filteredData.map((member) => {
-        return member.JpName ? member.JpName : false
-      })
-
-      // join all EnName and JpName to one array
-      const allNames = EnNames.concat(JpNames)
+      if (store.sorting.type === "jpname") {
+        names = names
+          .map((member) => member.JpName)
+          .filter((name) => name !== "")
+      } else names = names.map((member) => member.EnName)
 
       // random one name from allNames
-      const randomName = allNames[Math.floor(Math.random() * allNames.length)]
+      const randomName = names[Math.floor(Math.random() * names.length)]
 
       return randomName || "Search Vtubers..."
     },

--- a/service/new-web-vue/src/components/MenuFilters/SortMenu.vue
+++ b/service/new-web-vue/src/components/MenuFilters/SortMenu.vue
@@ -44,7 +44,7 @@
               class="fa-fw navbar-submenu-item__svg"
               icon="arrow-down-a-z"
             />
-            <span class="navbar-submenu-item__span">JP Name (BETA)</span>
+            <span class="navbar-submenu-item__span">Japanese Name</span>
           </a>
         </li>
 

--- a/service/new-web-vue/src/components/MenuFilters/SortMenu.vue
+++ b/service/new-web-vue/src/components/MenuFilters/SortMenu.vue
@@ -44,7 +44,7 @@
               class="fa-fw navbar-submenu-item__svg"
               icon="arrow-down-a-z"
             />
-            <span class="navbar-submenu-item__span">Japanese Name</span>
+            <span class="navbar-submenu-item__span">JP Name (BETA)</span>
           </a>
         </li>
 

--- a/service/new-web-vue/src/components/MenuFilters/SortMenu.vue
+++ b/service/new-web-vue/src/components/MenuFilters/SortMenu.vue
@@ -31,6 +31,23 @@
           </a>
         </li>
 
+        <li class="navbar-submenu-item">
+          <a
+            href="#"
+            @click="setSort('jpname')"
+            class="navbar-submenu-item__link"
+            :class="{
+              active: sorting.type === 'jpname',
+            }"
+          >
+            <font-awesome-icon
+              class="fa-fw navbar-submenu-item__svg"
+              icon="arrow-down-a-z"
+            />
+            <span class="navbar-submenu-item__span">Japanese Name</span>
+          </a>
+        </li>
+
         <li class="navbar-submenu-item" v-if="platforms.includes('youtube')">
           <a
             href="#"
@@ -49,7 +66,7 @@
         <li class="navbar-submenu-item" v-if="platforms.includes('youtube')">
           <a
             href="#"
-            @click="setSort(`youtube-views`)"
+            @click="setSort(`youtube_views`)"
             class="navbar-submenu-item__link"
             :class="{ active: sorting.type === 'youtube_views' }"
           >

--- a/service/new-web-vue/src/components/VtuberCard.vue
+++ b/service/new-web-vue/src/components/VtuberCard.vue
@@ -300,7 +300,7 @@ export default {
   }
 
   &-link {
-    @apply flex h-6 items-center overflow-hidden rounded-bl-md bg-slate-100/75 font-semibold text-white dark:bg-slate-500/80;
+    @apply flex h-6 items-center overflow-hidden rounded-bl-md bg-slate-100/75 font-semibold text-slate-600 dark:bg-slate-500/80 dark:text-white;
 
     // check when no child
     &:empty {
@@ -308,10 +308,10 @@ export default {
     }
 
     &__item {
-      @apply h-full px-1 py-[3px] transition-colors duration-200 ease-in-out first:pl-[6px] last:pr-[6px] hover:bg-white/20;
+      @apply h-full px-1 py-[3px] transition-colors duration-200 ease-in-out first:pl-[6px] last:pr-[6px] hover:bg-slate-600/20 dark:hover:bg-white/20;
 
       &.live {
-        @apply bg-red-600 hover:bg-red-300;
+        @apply bg-red-600 text-white hover:bg-red-300;
       }
     }
   }

--- a/service/new-web-vue/src/components/VtuberCard.vue
+++ b/service/new-web-vue/src/components/VtuberCard.vue
@@ -37,33 +37,6 @@
             } ${vtuber.Status === "Inactive" ? ` (Inactive)` : ""}`
           }}</span>
         </div>
-        <!-- <a
-          class="tag-vtuber-live"
-          v-if="
-            vtuber.IsLive.Youtube ||
-            vtuber.IsLive.Twitch ||
-            vtuber.IsLive.BiliBili
-          "
-          :href="liveLink"
-          target="_blank"
-        >
-          <font-awesome-icon
-            :icon="['fab', 'youtube']"
-            class="fa-fw"
-            v-if="vtuber.IsLive.Youtube"
-          />
-          <font-awesome-icon
-            :icon="['fab', 'twitch']"
-            class="fa-fw"
-            v-if="vtuber.IsLive.Twitch"
-          />
-          <font-awesome-icon
-            :icon="['fab', 'bilibili']"
-            class="fa-fw"
-            v-if="vtuber.IsLive.BiliBili"
-          />
-          <span>LIVE</span>
-        </a> -->
         <div class="tag-vtuber-link">
           <a
             class="tag-vtuber-link__item"
@@ -138,7 +111,29 @@
           alt="Card image cap"
         />
       </router-link>
-      <div class="vtuber-link"></div>
+      <div class="vtuber-link" v-if="type !== 'name' && type !== 'jpname'">
+        <font-awesome-icon
+          class="fa-fw"
+          :icon="['fab', 'youtube']"
+          v-if="type.includes('youtube')"
+        />
+        <font-awesome-icon
+          class="fa-fw"
+          :icon="['fab', 'twitch']"
+          v-if="type.includes('twitch')"
+        />
+        <font-awesome-icon
+          class="fa-fw"
+          :icon="['fab', 'bilibili']"
+          v-if="type.includes('bilibili')"
+        />
+        <font-awesome-icon
+          class="fa-fw"
+          :icon="['fab', 'twitter']"
+          v-if="type.includes('twitter')"
+        />
+        <span>{{ `${countSort} ${textCount}` }}</span>
+      </div>
     </div>
     <div class="card-vtuber-name">
       <router-link :to="`/vtuber/${vtuber.ID}`" class="card-vtuber-name__link">
@@ -194,6 +189,9 @@ export default {
         return `https://space.bilibili.com/${this.vtuber.BiliBili.SpaceID}`
       else return null
     },
+    type() {
+      return useMemberStore().sorting.type
+    },
     titleName() {
       if (useMemberStore().sorting.type === "jpname")
         return this.vtuber.JpName ? this.vtuber.JpName : this.vtuber.EnName
@@ -222,7 +220,18 @@ export default {
         return this.vtuber.Youtube
           ? this.FormatNumber(this.vtuber.Youtube.ViwersCount)
           : 0
+      else if (type === "bilibili_views")
+        return this.vtuber.BiliBili
+          ? this.FormatNumber(this.vtuber.BiliBili.ViwersCount)
+          : 0
       else return 0
+    },
+    textCount() {
+      const type = useMemberStore().sorting.type
+
+      if (type === "youtube") return "Subscribers"
+      else if (type.includes("views")) return "Views"
+      else return "Followers"
     },
   },
   methods: {
@@ -312,11 +321,7 @@ export default {
 }
 
 .vtuber-link {
-  @apply absolute bottom-0 right-0 space-x-1  rounded-tl-md bg-slate-100/80 px-[0.325rem] dark:bg-slate-500/80;
-
-  &__link {
-    @apply inline-block py-[0.125rem] px-1 text-stone-700 transition-colors duration-200 ease-in-out dark:text-slate-50;
-  }
+  @apply absolute bottom-0 right-0 space-x-1 rounded-tl-md bg-slate-100/80 px-[0.325rem] text-sm dark:bg-slate-500/80;
 }
 
 .inactive {

--- a/service/new-web-vue/src/components/VtuberCard.vue
+++ b/service/new-web-vue/src/components/VtuberCard.vue
@@ -32,9 +32,7 @@
             v-if="vtuber.Status == 'Inactive'"
           />
           <span class="tag-vtuber-agency__hover">{{
-            `${vtuber.Group.ID === 10 ? `Vtuber` : GroupName} ${
-              vtuber.Regions?.name || vtuber.Region
-            } ${vtuber.Status === "Inactive" ? ` (Inactive)` : ""}`
+            `${agencyName} ${vtuber.Status === "Inactive" ? ` (Inactive)` : ""}`
           }}</span>
         </div>
         <div class="tag-vtuber-link">
@@ -196,6 +194,17 @@ export default {
       if (useMemberStore().sorting.type === "jpname")
         return this.vtuber.JpName ? this.vtuber.JpName : this.vtuber.EnName
       else return this.vtuber.EnName
+    },
+    agencyName() {
+      if (this.vtuber.Agency) {
+        if (this.vtuber.Agency.match(/^\$/g))
+          return this.vtuber.Agency.replace(/^\$/, "")
+        else
+          return `${this.vtuber.Agency} (${this.vtuber.Group.GroupName} ${this.vtuber.Region})`
+      } else
+        return `${
+          this.vtuber.Group.ID === 10 ? `Vtuber` : this.vtuber.Group.GroupName
+        } ${this.vtuber.Regions?.name || this.vtuber.Region}`
     },
     countSort() {
       const type = useMemberStore().sorting.type

--- a/service/new-web-vue/src/components/VtuberCard.vue
+++ b/service/new-web-vue/src/components/VtuberCard.vue
@@ -8,7 +8,7 @@
             class="tag-vtuber-agency__icon"
             :src="vtuber.Group.IconURL"
             :alt="vtuber.Group.GroupName"
-            v-if="vtuber.Group.ID !== 10"
+            v-if="$route.params.id != vtuber.Group.ID && vtuber.Group.ID !== 10"
           />
           <img
             draggable="false"
@@ -16,7 +16,7 @@
             :src="`/assets/flags/${vtuber.Regions?.code.toLowerCase()}.svg`"
             :alt="vtuber.Regions.name"
             onerror="this.src='/assets/flags/none.svg'"
-            v-if="vtuber.Regions"
+            v-else-if="vtuber.Regions"
           />
           <img
             draggable="false"
@@ -37,7 +37,7 @@
             } ${vtuber.Status === "Inactive" ? ` (Inactive)` : ""}`
           }}</span>
         </div>
-        <a
+        <!-- <a
           class="tag-vtuber-live"
           v-if="
             vtuber.IsLive.Youtube ||
@@ -63,7 +63,44 @@
             v-if="vtuber.IsLive.BiliBili"
           />
           <span>LIVE</span>
-        </a>
+        </a> -->
+        <div class="tag-vtuber-link">
+          <a
+            class="tag-vtuber-link__item"
+            :class="{ live: vtuber.IsLive.Youtube }"
+            :href="ytLink"
+            target="_blank"
+            v-if="vtuber.Youtube"
+          >
+            <font-awesome-icon class="fa-fw" :icon="['fab', 'youtube']" />
+          </a>
+          <a
+            class="tag-vtuber-link__item"
+            :class="{ live: vtuber.IsLive.Twitch }"
+            :href="`https://twitch.tv/${vtuber.Twitch.Username}`"
+            target="_blank"
+            v-if="vtuber.Twitch"
+          >
+            <font-awesome-icon class="fa-fw" :icon="['fab', 'twitch']" />
+          </a>
+          <a
+            class="tag-vtuber-link__item"
+            :class="{ live: vtuber.IsLive.BiliBili }"
+            :href="blLink"
+            target="_blank"
+            v-if="vtuber.BiliBili"
+          >
+            <font-awesome-icon class="fa-fw" :icon="['fab', 'bilibili']" />
+          </a>
+          <a
+            class="tag-vtuber-link__item"
+            :href="`https://twitter.com/${vtuber.Twitter.Username}`"
+            target="_blank"
+            v-if="vtuber.Twitter"
+          >
+            <font-awesome-icon class="fa-fw" :icon="['fab', 'twitter']" />
+          </a>
+        </div>
       </div>
       <router-link :to="`/vtuber/${vtuber.ID}`" class="card-vtuber-image__link">
         <img
@@ -101,66 +138,12 @@
           alt="Card image cap"
         />
       </router-link>
-      <div class="vtuber-link">
-        <a
-          :href="`https://youtube.com/channel/${vtuber.Youtube.YoutubeID}`"
-          target="_blank"
-          class="vtuber-link__link hover:!text-youtube"
-          rel="noopener noreferrer"
-          v-if="vtuber.Youtube"
-        >
-          <font-awesome-icon
-            :icon="['fab', 'youtube']"
-            class="fa-fw"
-            rel="noopener noreferrer"
-            v-if="vtuber.Youtube"
-          />
-        </a>
-        <a
-          :href="`https://twitch.tv/${vtuber.Twitch.Username}`"
-          target="_blank"
-          class="vtuber-link__link hover:!text-twitch"
-          rel="noopener noreferrer"
-          v-if="vtuber.Twitch"
-        >
-          <font-awesome-icon
-            :icon="['fab', 'twitch']"
-            class="fa-fw"
-            v-if="vtuber.Twitch"
-          />
-        </a>
-        <a
-          :href="`https://space.bilibili.com/${vtuber.BiliBili.SpaceID}`"
-          target="_blank"
-          class="vtuber-link__link hover:!text-bilibili"
-          rel="noopener noreferrer"
-          v-if="vtuber.BiliBili"
-        >
-          <font-awesome-icon
-            :icon="['fab', 'bilibili']"
-            class="fa-fw"
-            v-if="vtuber.BiliBili"
-          />
-        </a>
-        <a
-          :href="`https://twitter.com/${vtuber.Twitter.Username}`"
-          target="_blank"
-          class="vtuber-link__link hover:!text-twitter"
-          rel="noopener noreferrer"
-          v-if="vtuber.Twitter"
-        >
-          <font-awesome-icon
-            :icon="['fab', 'twitter']"
-            class="fa-fw"
-            v-if="vtuber.Twitter"
-          />
-        </a>
-      </div>
+      <div class="vtuber-link"></div>
     </div>
     <div class="card-vtuber-name">
       <router-link :to="`/vtuber/${vtuber.ID}`" class="card-vtuber-name__link">
         <h4 class="card-vtuber-name__title">
-          {{ vtuber.EnName }}
+          {{ titleName }}
         </h4>
         <span class="card-vtuber-name__nickname">
           {{ vtuber.NickName.toLowerCase() }}
@@ -183,25 +166,73 @@ import {
 
 library.add(faYoutube, faTwitch, faBilibili, faTwitter, faSkull)
 
+import { useMemberStore } from "@/stores/members.js"
+
 export default {
   props: {
     vtuber: {
       type: Object,
     },
   },
-  async created() {},
   computed: {
-    liveLink() {
-      if (this.vtuber.IsLive.Youtube) return this.vtuber.IsLive.Youtube.URL
-      else if (this.vtuber.IsLive.Twitch) return this.vtuber.IsLive.Twitch.URL
-      else return this.vtuber.IsLive.BiliBili.URL
-    },
     randomAvatar() {},
     GroupName() {
       return (
         this.vtuber.Group.GroupName.charAt(0).toUpperCase() +
         this.vtuber.Group.GroupName.slice(1).replace("_", " ")
       )
+    },
+    ytLink() {
+      if (this.vtuber.IsLive?.Youtube) return this.vtuber.IsLive.Youtube.URL
+      else if (this.vtuber.Youtube)
+        return `https://youtube.com/channel/${this.vtuber.Youtube.YoutubeID}`
+      else return null
+    },
+    blLink() {
+      if (this.vtuber.IsLive.BiliBili) return this.vtuber.IsLive.BiliBili.URL
+      else if (this.vtuber.BiliBili)
+        return `https://space.bilibili.com/${this.vtuber.BiliBili.SpaceID}`
+      else return null
+    },
+    titleName() {
+      if (useMemberStore().sorting.type === "jpname")
+        return this.vtuber.JpName ? this.vtuber.JpName : this.vtuber.EnName
+      else return this.vtuber.EnName
+    },
+    countSort() {
+      const type = useMemberStore().sorting.type
+
+      if (type === "youtube")
+        return this.vtuber.Youtube
+          ? this.FormatNumber(this.vtuber.Youtube.Subscriber)
+          : 0
+      else if (type === "bilibili")
+        return this.vtuber.BiliBili
+          ? this.FormatNumber(this.vtuber.BiliBili.Followers)
+          : 0
+      else if (type === "twitch")
+        return this.vtuber.Twitch
+          ? this.FormatNumber(this.vtuber.Twitch.Followers)
+          : 0
+      else if (type === "twitter")
+        return this.vtuber.Twitter
+          ? this.FormatNumber(this.vtuber.Twitter.Followers)
+          : 0
+      else if (type === "youtube_views")
+        return this.vtuber.Youtube
+          ? this.FormatNumber(this.vtuber.Youtube.ViwersCount)
+          : 0
+      else return 0
+    },
+  },
+  methods: {
+    FormatNumber(num) {
+      // Ensure number has max 3 significant digits (no rounding up can happen)
+
+      if (num >= 1000000000) return (num / 1000000000).toFixed(2) + "B"
+      else if (num >= 1000000) return (num / 1000000).toFixed(2) + "M"
+      else if (num >= 1000) return (num / 1000).toFixed(2) + "K"
+      else return num
     },
   },
 }
@@ -231,10 +262,10 @@ export default {
 }
 
 .tag-vtuber {
-  @apply absolute flex select-none items-center rounded-br-md bg-slate-100/80 text-xs dark:bg-slate-500/80;
+  @apply absolute flex w-full select-none items-center justify-between text-sm;
 
   &-agency {
-    @apply flex h-6 cursor-pointer items-center justify-center space-x-2 px-[0.325rem];
+    @apply flex h-6 cursor-pointer items-center justify-center space-x-2 rounded-br-md bg-slate-100/75 px-[0.325rem] dark:bg-slate-500/80;
 
     &__icon {
       @apply w-5 rounded-md object-contain drop-shadow-md;
@@ -259,8 +290,24 @@ export default {
     @apply hidden;
   }
 
-  &-live {
-    @apply flex h-6 items-center space-x-1 rounded-br-md bg-red-500 px-[0.325rem] font-semibold text-white;
+  // &-live {
+  //   @apply flex h-6 items-center space-x-1 rounded-br-md bg-red-500 px-[0.325rem] font-semibold text-white;
+  // }
+  &-link {
+    @apply flex h-6 items-center overflow-hidden rounded-bl-md bg-slate-100/75 font-semibold text-white dark:bg-slate-500/80;
+
+    // check when no child
+    &:empty {
+      @apply px-0;
+    }
+
+    &__item {
+      @apply h-full px-1 py-[3px] first:pl-[6px] last:pr-[6px];
+
+      &.live {
+        @apply bg-red-600;
+      }
+    }
   }
 }
 

--- a/service/new-web-vue/src/components/VtuberCard.vue
+++ b/service/new-web-vue/src/components/VtuberCard.vue
@@ -1,30 +1,41 @@
 <template>
-  <div class="card-vtuber" :class="{ inactive: vtuber.Status == 'Inactive' }">
+  <div
+    class="card-vtuber"
+    :class="{ inactive: vtuber.Status == 'Inactive' }"
+    :data-id="vtuber.ID"
+  >
     <div class="card-vtuber-image">
       <div class="tag-vtuber">
         <div class="tag-vtuber-agency">
-          <img
-            draggable="false"
-            class="tag-vtuber-agency__icon"
-            :src="vtuber.Group.IconURL"
-            :alt="vtuber.Group.GroupName"
-            v-if="$route.params.id != vtuber.Group.ID && vtuber.Group.ID !== 10"
-          />
-          <img
-            draggable="false"
-            class="tag-vtuber-agency__flag"
-            :src="`/assets/flags/${vtuber.Regions?.code.toLowerCase()}.svg`"
-            :alt="vtuber.Regions.name"
-            onerror="this.src='/assets/flags/none.svg'"
-            v-else-if="vtuber.Regions"
-          />
-          <img
-            draggable="false"
-            class="tag-vtuber-agency__flag"
-            src="/assets/flags/none.svg"
-            :alt="vtuber.Region"
-            v-else
-          />
+          <router-link
+            :to="`/vtubers/` + vtuber.Group.ID"
+            @click="getVtuberData(vtuber.Group.ID)"
+          >
+            <img
+              draggable="false"
+              class="tag-vtuber-agency__icon"
+              :src="vtuber.Group.IconURL"
+              :alt="vtuber.Group.GroupName"
+              v-if="
+                $route.params.id != vtuber.Group.ID && vtuber.Group.ID !== 10
+              "
+            />
+            <img
+              draggable="false"
+              class="tag-vtuber-agency__flag"
+              :src="`/assets/flags/${vtuber.Regions?.code.toLowerCase()}.svg`"
+              :alt="vtuber.Regions.name"
+              onerror="this.src='/assets/flags/none.svg'"
+              v-else-if="vtuber.Regions"
+            />
+            <img
+              draggable="false"
+              class="tag-vtuber-agency__flag"
+              src="/assets/flags/none.svg"
+              :alt="vtuber.Region"
+              v-else
+            />
+          </router-link>
 
           <font-awesome-icon
             class="fa-fw"
@@ -77,36 +88,10 @@
         <img
           draggable="false"
           class="card-vtuber-image__img"
-          v-if="vtuber.Youtube"
-          v-bind:src="vtuber.Youtube.Avatar.replace('s800', 's360')"
+          :src="avatar"
           referrerpolicy="no-referrer"
           onerror="this.src='/assets/smolame.jpg'"
-          alt="Card image cap"
-        />
-        <img
-          draggable="false"
-          class="card-vtuber-image__img"
-          v-else-if="vtuber.BiliBili"
-          v-bind:src="`${vtuber.BiliBili.Avatar}@360w_360h_1c_1s.jpg`"
-          referrerpolicy="no-referrer"
-          onerror="this.src='/assets/smolame.jpg'"
-          alt="Card image cap"
-        />
-        <img
-          draggable="false"
-          class="card-vtuber-image__img"
-          v-else-if="vtuber.Twitch"
-          v-bind:src="vtuber.Twitch.Avatar"
-          referrerpolicy="no-referrer"
-          onerror="this.src='/assets/smolame.jpg'"
-          alt="Card image cap"
-        />
-        <img
-          draggable="false"
-          class="card-vtuber-image__img"
-          v-else
-          src="/assets/smolame.jpg"
-          alt="Card image cap"
+          :alt="vtuber.EnName"
         />
       </router-link>
       <div class="vtuber-link" v-if="type !== 'name' && type !== 'jpname'">
@@ -168,7 +153,17 @@ export default {
     },
   },
   computed: {
-    randomAvatar() {},
+    avatar() {
+      return this.vtuber.Youtube
+        ? this.vtuber.Youtube.Avatar.replace("s800", "s360")
+        : this.vtuber.BiliBili
+        ? `${this.vtuber.BiliBili.Avatar}@360w_360h_1c_1s.jpg`
+        : this.vtuber.Twitch
+        ? this.vtuber.Twitch.Avatar
+        : this.vtuber.Twitter
+        ? this.vtuber.Twitter.Avatar
+        : "/assets/smolame.jpg"
+    },
     GroupName() {
       return (
         this.vtuber.Group.GroupName.charAt(0).toUpperCase() +
@@ -251,6 +246,11 @@ export default {
       else if (num >= 1000000) return (num / 1000000).toFixed(2) + "M"
       else if (num >= 1000) return (num / 1000).toFixed(2) + "K"
       else return num
+    },
+    async getVtuberData(id) {
+      await useMemberStore().fetchMembers(id || null)
+      useMemberStore().filterMembers()
+      useMemberStore().sortingMembers()
     },
   },
 }

--- a/service/new-web-vue/src/components/VtuberCard.vue
+++ b/service/new-web-vue/src/components/VtuberCard.vue
@@ -39,7 +39,7 @@
         </div>
         <div class="tag-vtuber-link">
           <a
-            class="tag-vtuber-link__item"
+            class="tag-vtuber-link__item hover:!text-youtube"
             :class="{ live: vtuber.IsLive.Youtube }"
             :href="ytLink"
             target="_blank"
@@ -48,7 +48,7 @@
             <font-awesome-icon class="fa-fw" :icon="['fab', 'youtube']" />
           </a>
           <a
-            class="tag-vtuber-link__item"
+            class="tag-vtuber-link__item hover:!text-twitch"
             :class="{ live: vtuber.IsLive.Twitch }"
             :href="`https://twitch.tv/${vtuber.Twitch.Username}`"
             target="_blank"
@@ -57,7 +57,7 @@
             <font-awesome-icon class="fa-fw" :icon="['fab', 'twitch']" />
           </a>
           <a
-            class="tag-vtuber-link__item"
+            class="tag-vtuber-link__item hover:!text-bilibili"
             :class="{ live: vtuber.IsLive.BiliBili }"
             :href="blLink"
             target="_blank"
@@ -66,7 +66,7 @@
             <font-awesome-icon class="fa-fw" :icon="['fab', 'bilibili']" />
           </a>
           <a
-            class="tag-vtuber-link__item"
+            class="tag-vtuber-link__item hover:!text-twitter"
             :href="`https://twitter.com/${vtuber.Twitter.Username}`"
             target="_blank"
             v-if="vtuber.Twitter"
@@ -299,9 +299,6 @@ export default {
     @apply hidden;
   }
 
-  // &-live {
-  //   @apply flex h-6 items-center space-x-1 rounded-br-md bg-red-500 px-[0.325rem] font-semibold text-white;
-  // }
   &-link {
     @apply flex h-6 items-center overflow-hidden rounded-bl-md bg-slate-100/75 font-semibold text-white dark:bg-slate-500/80;
 
@@ -311,10 +308,10 @@ export default {
     }
 
     &__item {
-      @apply h-full px-1 py-[3px] first:pl-[6px] last:pr-[6px];
+      @apply h-full px-1 py-[3px] transition-colors duration-200 ease-in-out first:pl-[6px] last:pr-[6px] hover:bg-white/20;
 
       &.live {
-        @apply bg-red-600;
+        @apply bg-red-600 hover:bg-red-300;
       }
     }
   }

--- a/service/new-web-vue/src/components/VtuberList.vue
+++ b/service/new-web-vue/src/components/VtuberList.vue
@@ -83,11 +83,10 @@ export default {
       limitedVtubers: [],
       nullData: false,
       hide_scroll_up: true,
-      regions: null,
+      regions: regionConfig,
     }
   },
   created() {
-    this.regions = regionConfig
     const store = useMemberStore()
 
     this.$watch(
@@ -114,9 +113,6 @@ export default {
       return store.members.searchedData.length > 0
         ? store.members.searchedData
         : store.members.filteredData
-    },
-    test() {
-      return this.vtubers.length
     },
   },
   methods: {

--- a/service/new-web-vue/src/components/docs/FAQ.md
+++ b/service/new-web-vue/src/components/docs/FAQ.md
@@ -1,0 +1,3 @@
+# Frequently Askes Questions
+
+- 

--- a/service/new-web-vue/src/dummy.json
+++ b/service/new-web-vue/src/dummy.json
@@ -1,0 +1,43 @@
+{
+  "ID": 1,
+  "NickName": "Dummy",
+  "EnName": "Dummy",
+  "JpName": "",
+  "Region": "JP",
+  "Fanbase": "",
+  "Status": "Active",
+  "BiliBili": {
+    "Avatar": "",
+    "Followers": 164242,
+    "LiveID": 22347054,
+    "SpaceID": 623441612,
+    "ViwersCount": 0
+  },
+  "Youtube": {
+    "Avatar": "",
+    "Subscriber": 23700,
+    "ViwersCount": 420097,
+    "YoutubeID": "UC0lIq8G4LgDPlXsDmYSUExw"
+  },
+  "Twitter": {
+    "Avatar": "",
+    "Followers": 19053,
+    "Username": "futamiyarn"
+  },
+  "Twitch": {
+    "Avatar": "https://static-cdn.jtvnw.net/jtv_user_pictures/22073c2b-0662-46c7-93fb-fe081cd90e80-profile_image-300x300.png",
+    "Followers": 55261,
+    "Username": "robocosan_hololive",
+    "ViwersCount": 66959
+  },
+  "Group": {
+    "GroupName": "independent",
+    "ID": 10,
+    "IconURL": "https://cdn.humanz.moe/404.jpg"
+  },
+  "IsLive": {
+    "BiliBili": { "URL": "https://youtube.com/" },
+    "Twitch": { "URL": "https://youtube.com/" },
+    "Youtube": { "URL": "https://youtube.com/" }
+  }
+}

--- a/service/new-web-vue/src/stores/members.js
+++ b/service/new-web-vue/src/stores/members.js
@@ -3,6 +3,7 @@ import { ref, computed, compile, toRaw } from "vue"
 import axios from "axios"
 import Config from "../config.json"
 import regionConfig from "../regions.json"
+import agencysConfig from "../agency.json"
 import parse from "url-parse"
 import { useLocalStorage } from "@vueuse/core"
 import { toRomaji } from "wanakana"
@@ -70,11 +71,25 @@ export const useMemberStore = defineStore("members", () => {
     if (err) return false
 
     vtuber_data.forEach((vtuber) => {
-      regionConfig.forEach((region) => {
+      for (const region of regionConfig) {
         if (region.code === vtuber.Region) {
           vtuber.Regions = region
+          break
         }
-      })
+      }
+
+      // split object into array
+      const arrAgencys = Object.entries(agencysConfig)
+
+      // loop through array
+      for (const [key, value] of arrAgencys) {
+        const bindingKey = `${vtuber.Group.ID}:${vtuber.Region.toLowerCase()}`
+
+        if (key === bindingKey) {
+          vtuber.Agency = value
+          break
+        }
+      }
     })
 
     console.log(`[MEMBERS] Total member: ${vtuber_data.length}`)

--- a/service/new-web-vue/src/stores/members.js
+++ b/service/new-web-vue/src/stores/members.js
@@ -7,6 +7,7 @@ import agencysConfig from "../agency.json"
 import parse from "url-parse"
 import { useLocalStorage } from "@vueuse/core"
 import { toRomaji } from "wanakana"
+import dummy from "../dummy.json"
 
 export const useMemberStore = defineStore("members", () => {
   const members = ref({
@@ -24,6 +25,7 @@ export const useMemberStore = defineStore("members", () => {
     platform: [],
     live: [],
     inactive: false,
+    open_advanced: false,
   })
   const sortMenu = ref({ platform: [], twitter: false })
 
@@ -42,6 +44,9 @@ export const useMemberStore = defineStore("members", () => {
       inactive: true,
     })
   )
+
+  const toggleadvanced = () =>
+    (menuFilter.value.open_advanced = !menuFilter.value.open_advanced)
 
   const fetchMembers = async (id = null) => {
     let err = false
@@ -70,6 +75,8 @@ export const useMemberStore = defineStore("members", () => {
 
     if (err) return false
 
+    // vtuber_data.push(dummy)
+
     vtuber_data.forEach((vtuber) => {
       for (const region of regionConfig) {
         if (region.code === vtuber.Region) {
@@ -78,18 +85,18 @@ export const useMemberStore = defineStore("members", () => {
         }
       }
 
-      // split object into array
-      const arrAgencys = Object.entries(agencysConfig)
+      // // split object into array
+      // const arrAgencys = Object.entries(agencysConfig)
 
-      // loop through array
-      for (const [key, value] of arrAgencys) {
-        const bindingKey = `${vtuber.Group.ID}:${vtuber.Region.toLowerCase()}`
+      // // loop through array
+      // for (const [key, value] of arrAgencys) {
+      //   const bindingKey = `${vtuber.Group.ID}:${vtuber.Region.toLowerCase()}`
 
-        if (key === bindingKey) {
-          vtuber.Agency = value
-          break
-        }
-      }
+      //   if (key === bindingKey) {
+      //     vtuber.Agency = value
+      //     break
+      //   }
+      // }
     })
 
     console.log(`[MEMBERS] Total member: ${vtuber_data.length}`)
@@ -163,7 +170,7 @@ export const useMemberStore = defineStore("members", () => {
   }
 
   const filterMembers = () => {
-    const { reg, plat, liveplat, nolive, inac } = parse(
+    const { reg, plat, liveplat, liveonly, inac } = parse(
       window.location.href,
       true
     ).query
@@ -173,7 +180,9 @@ export const useMemberStore = defineStore("members", () => {
     filter.value.region = regions
     filter.value.platform = plat ? plat : null
     filter.value.live = liveplat ? liveplat : null
-    filter.value.live_only = nolive?.toLowerCase() == "false" ? true : false
+    filter.value.live_only = liveonly
+      ? liveonly.toLowerCase() === "true"
+      : false
     filter.value.inactive = inac ? inac.toLowerCase() === "true" : false
 
     let { region, platform, live, live_only, inactive } = filter.value
@@ -431,6 +440,7 @@ export const useMemberStore = defineStore("members", () => {
     sortMenu,
     filter,
     sorting,
+    toggleadvanced,
     fetchMembers,
     filterMembers,
     changeSort,

--- a/service/new-web-vue/src/stores/members.js
+++ b/service/new-web-vue/src/stores/members.js
@@ -5,6 +5,7 @@ import Config from "../config.json"
 import regionConfig from "../regions.json"
 import parse from "url-parse"
 import { useLocalStorage } from "@vueuse/core"
+import { toRomaji } from "wanakana"
 
 export const useMemberStore = defineStore("members", () => {
   const members = ref({
@@ -304,9 +305,12 @@ export const useMemberStore = defineStore("members", () => {
     // sort jp name
     if (type.toLowerCase() === "jpname") {
       console.log("[MEMBERS] Sorting by Japanese name")
-      vtuber_data.sort(({ JpName: nameA }, { JpName: nameB }) =>
-        nameA.localeCompare(nameB)
-      )
+      vtuber_data.sort(({ JpName: nameA }, { JpName: nameB }) => {
+        const latinA = toRomaji(nameA).toLowerCase().replace("/", " ")
+        const latinB = toRomaji(nameB).toLowerCase().replace("/", " ")
+
+        return latinA.localeCompare(latinB)
+      })
       vtuber_data.sort(({ JpName: nameA }, { JpName: nameB }) => {
         if (!nameA.charAt(0) && nameB.charAt(0)) return 1
         if (nameA.charAt(0) && !nameB.charAt(0)) return -1

--- a/service/new-web-vue/src/stores/members.js
+++ b/service/new-web-vue/src/stores/members.js
@@ -84,6 +84,8 @@ export const useMemberStore = defineStore("members", () => {
         nameA.toLowerCase() < nameB.toLowerCase() ? -1 : 1
     )
 
+    console.log(vtuber_data)
+
     let newRegion = []
     let newPlatform = []
     let newLive = []
@@ -294,11 +296,23 @@ export const useMemberStore = defineStore("members", () => {
 
     vtuber_data.sort(
       // sort by name
-      ({ EnName: nameA }, { EnName: nameB }) =>
-        nameA.toLowerCase() < nameB.toLowerCase() ? -1 : 1
+      ({ EnName: nameA }, { EnName: nameB }) => nameA.localeCompare(nameB)
     )
 
     if (type.toLowerCase() === "name") console.log("[MEMBERS] Sorting by name")
+
+    // sort jp name
+    if (type.toLowerCase() === "jpname") {
+      console.log("[MEMBERS] Sorting by Japanese name")
+      vtuber_data.sort(({ JpName: nameA }, { JpName: nameB }) =>
+        nameA.localeCompare(nameB)
+      )
+      vtuber_data.sort(({ JpName: nameA }, { JpName: nameB }) => {
+        if (!nameA.charAt(0) && nameB.charAt(0)) return 1
+        if (nameA.charAt(0) && !nameB.charAt(0)) return -1
+        return 0
+      })
+    }
 
     if (type.toLowerCase() === "youtube") {
       console.log("[MEMBERS] Sort by youtube subscribers")

--- a/service/new-web-vue/src/views/ListView.vue
+++ b/service/new-web-vue/src/views/ListView.vue
@@ -7,38 +7,43 @@ import ExtendFilter from "../components/ExtendFilter.vue"
 </script>
 
 <template>
-  <!-- <ExtendFilter /> -->
+  <div v-if="advanced_open">
+    <ExtendFilter />
+  </div>
   <NavbarList />
-  <AmeLoading v-if="vtubersCount < 1 && !error_status" class="!h-screen" />
+  <VtuberList v-if="vtubersCount > 0 && !error_status" />
+  <AmeLoading
+    v-else-if="!query && totalVtubersData < 1 && !error_status"
+    class="!h-screen"
+  />
   <AmeError
-    v-if="vtubersCount > 0 && filteredCount < 1"
+    v-else-if="vtubersCount < 1 && totalVtubersData > 0 && !error_status"
     type="error"
     img="laptop"
     title="Your filter is incorrect"
     :description="`Check your filter. Or when your vtuber is not available, request ${link_request}`"
   />
   <AmeError
-    v-if="vtubersCount > 0 && query && searchedCount < 1"
+    v-else-if="query && vtubersCount < 1"
     type="warning"
     img="bugs"
     title="You find worng keyword"
     :description="`When your vtuber/member is not here, your can request ${link_request}, or try another keyword`"
   />
   <AmeError
-    v-if="vtubersCount < 1 && error_status && error_status === 404"
+    v-else-if="totalVtubersData < 1 && error_status && error_status === 404"
     type="error"
     img="laptop"
     title="Your group is not available"
     :description="`Check another available group, or you can request a group ${link_request}`"
   />
   <AmeError
-    v-if="vtubersCount < 1 && error_status && error_status !== 404"
+    v-else-if="totalVtubersData < 1 && error_status && error_status !== 404"
     type="error"
     img="lazer"
     title="Something wrong when get request"
     :description="`Waiting for server response, restart your WiFi, or try again later`"
   />
-  <VtuberList v-if="vtubersCount > 0" />
 </template>
 
 <script>
@@ -70,26 +75,30 @@ export default {
         }
       }
     )
+    console.log(this.totalVtubersData)
+    console.log(this.vtubersCount)
   },
   computed: {
     link_request() {
       return `<a href="/new-vtuber" id="router-link" class="ame-error-text__link">here</a>`
     },
-    filteredCount() {
+    totalVtubersData() {
       this.calculateFilters()
-      return useMemberStore().members.filteredData.length
+      return useMemberStore().members.data.length
     },
     query() {
       return useMemberStore().members.query
     },
-    searchedCount() {
-      return useMemberStore().members.searchedData.length
-    },
     vtubersCount() {
-      return useMemberStore().members.data.length
+      this.calculateFilters()
+      if (this.query) return useMemberStore().members.searchedData.length
+      else return useMemberStore().members.filteredData.length
     },
     error_status() {
       return useMemberStore().members.status
+    },
+    advanced_open() {
+      return useMemberStore().menuFilter.open_advanced
     },
   },
   methods: {

--- a/service/new-web-vue/src/views/ListView.vue
+++ b/service/new-web-vue/src/views/ListView.vue
@@ -59,6 +59,17 @@ export default {
 
     // add abilty menu
     this.menuHandler()
+
+    this.$watch(
+      () => this.$route.params,
+      async (af, bf) => {
+        if (!af?.id && bf?.id) {
+          await useMemberStore().fetchMembers(null)
+          useMemberStore().filterMembers()
+          useMemberStore().sortingMembers()
+        }
+      }
+    )
   },
   computed: {
     link_request() {

--- a/service/new-web-vue/src/views/ListView.vue
+++ b/service/new-web-vue/src/views/ListView.vue
@@ -3,9 +3,11 @@ import NavbarList from "../components/MenuFilters/NavbarList.vue"
 import AmeLoading from "../components/AmeComp/AmeLoading.vue"
 import VtuberList from "../components/VtuberList.vue"
 import AmeError from "../components/AmeComp/AmeError.vue"
+import ExtendFilter from "../components/ExtendFilter.vue"
 </script>
 
 <template>
+  <!-- <ExtendFilter /> -->
   <NavbarList />
   <AmeLoading v-if="vtubersCount < 1 && !error_status" class="!h-screen" />
   <AmeError
@@ -84,8 +86,9 @@ export default {
       const router_before = window.history.state.back || ""
 
       if (
-        !router_before.includes("/vtuber") ||
-        useMemberStore().members.group !== this.$route.params?.id
+        (!router_before.includes("/vtuber") &&
+          useMemberStore().members.group !== this.$route.params?.id) ||
+        useMemberStore().members.group === -1
       )
         await useMemberStore().fetchMembers(this.$route.params?.id || null)
       useMemberStore().filterMembers()


### PR DESCRIPTION
### New Card Look
![Screenshot 2022-07-22 at 11-14-22 List Vtubers - Vtbot](https://user-images.githubusercontent.com/21020026/180361236-1330f64f-d4e6-4d02-81f8-c002b78948f1.png) **Before**

![Screenshot 2022-07-22 at 11-14-38 List Vtubers - Vtbot](https://user-images.githubusercontent.com/21020026/180361281-a4b1a559-91b3-43e6-8970-5ae695d7eefe.png) **After**

Now link platform move to top right, and change to red when they live. Flag hide when show all agency/group (except indie)

### Sorting Improvement

![ezgif com-gif-maker](https://user-images.githubusercontent.com/21020026/180363792-ed3d0cc7-2651-4e3f-9dad-4519aa807b45.gif)

Inspired by [Idolm@ster Cinderella Girls: Starlight Stage](https://en.wikipedia.org/wiki/The_Idolmaster_Cinderella_Girls:_Starlight_Stage) and [Idolm@ster Million live: Theater Days](https://project-imas.wiki/THE_iDOLM@STER_Million_Live!_Theater_Days), now you can show total subscriber/follower/viewers according to sorting type

### Japanese Name Sorting (Beta)

![Screenshot 2022-07-22 at 11-47-10 Nijisanji - List Vtubers](https://user-images.githubusercontent.com/21020026/180364768-fedb0abb-bed0-4d26-ae17-353e848582e9.png)

You can sorting name and change vtuber name to Japanese name instead Latin name when exist (issue: cannot translate kanji characters to romaji/latin characters so the results are different from what is displayed on the [Nijisanji website](https://www.nijisanji.jp/ja/members?order=name))

### Advanced Filter

![Screenshot 2022-07-22 at 11-49-29 List Vtubers - Vtbot](https://user-images.githubusercontent.com/21020026/180365016-8219ec2a-8f5e-44da-b9e2-778ff84e218a.png)

Now you can filtering 2 or more regions and have youtube only without twitch or bilibili with advanced filter

### Bug fixing

Some change code and hidden bug inside website
